### PR TITLE
Uf 4596 refactor db cleaning job

### DIFF
--- a/src/main/java/se/sundsvall/seabloader/integration/db/InvoiceRepository.java
+++ b/src/main/java/se/sundsvall/seabloader/integration/db/InvoiceRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import se.sundsvall.seabloader.integration.db.model.InvoiceEntity;
+import se.sundsvall.seabloader.integration.db.model.InvoiceId;
 import se.sundsvall.seabloader.integration.db.model.enums.Status;
 
 @Transactional
@@ -48,4 +49,12 @@ public interface InvoiceRepository extends JpaRepository<InvoiceEntity, Long>, J
 	 * @return amount of entities having matching the sent in statuses.
 	 */
 	long countByStatusIn(Status... statusList);
+
+	/**
+	 * Get ids of entities matching status in sent in status list.
+	 *
+	 * @param statusList a List of statuses to filter on.
+	 * @return A List of InvoiceId
+	 */
+	List<InvoiceId> findIdsByStatusIn(Status... statusList);
 }

--- a/src/main/java/se/sundsvall/seabloader/integration/db/model/InvoiceId.java
+++ b/src/main/java/se/sundsvall/seabloader/integration/db/model/InvoiceId.java
@@ -1,0 +1,5 @@
+package se.sundsvall.seabloader.integration.db.model;
+
+public interface InvoiceId {
+	long getId();
+}

--- a/src/main/java/se/sundsvall/seabloader/scheduler/dbcleaner/DatabaseCleanerSchedulerService.java
+++ b/src/main/java/se/sundsvall/seabloader/scheduler/dbcleaner/DatabaseCleanerSchedulerService.java
@@ -25,7 +25,7 @@ public class DatabaseCleanerSchedulerService extends AbstractScheduler {
 	private static final String LOG_NOTHING_TO_REMOVE = "No entities found with status {}, hence no obsolete entities to remove";
 	private static final String LOG_CLEANING_ENDED = "Cleaning of obsolete entities in database has ended";
 
-	private static final Status[] STATUSES_TO_REMOVE = { PROCESSED };
+	private static final Status[] STATUS_FOR_ENTITIES_TO_REMOVE = { PROCESSED };
 
 	@Autowired
 	private InvoiceRepository invoiceRepository;
@@ -35,19 +35,19 @@ public class DatabaseCleanerSchedulerService extends AbstractScheduler {
 	public void execute() {
 		LOGGER.info(LOG_CLEANING_STARTED);
 
-		final var entitiesToRemove = invoiceRepository.countByStatusIn(STATUSES_TO_REMOVE);
+		final var entitiesToRemove = invoiceRepository.countByStatusIn(STATUS_FOR_ENTITIES_TO_REMOVE);
 		if (entitiesToRemove > 0) {
-			LOGGER.info(LOG_ENTITIES_REMOVAL, entitiesToRemove, STATUSES_TO_REMOVE);
+			LOGGER.info(LOG_ENTITIES_REMOVAL, entitiesToRemove, STATUS_FOR_ENTITIES_TO_REMOVE);
 			invoiceRepository.deleteAllById(getIdsToRemove());
 		} else {
-			LOGGER.info(LOG_NOTHING_TO_REMOVE, (Object) STATUSES_TO_REMOVE);
+			LOGGER.info(LOG_NOTHING_TO_REMOVE, (Object) STATUS_FOR_ENTITIES_TO_REMOVE);
 		}
 
 		LOGGER.info(LOG_CLEANING_ENDED);
 	}
 
 	private List<Long> getIdsToRemove() {
-		return invoiceRepository.findIdsByStatusIn(STATUSES_TO_REMOVE)
+		return invoiceRepository.findIdsByStatusIn(STATUS_FOR_ENTITIES_TO_REMOVE)
 			.stream()
 			.map(InvoiceId::getId)
 			.toList();

--- a/src/main/java/se/sundsvall/seabloader/scheduler/dbcleaner/DatabaseCleanerSchedulerService.java
+++ b/src/main/java/se/sundsvall/seabloader/scheduler/dbcleaner/DatabaseCleanerSchedulerService.java
@@ -2,6 +2,8 @@ package se.sundsvall.seabloader.scheduler.dbcleaner;
 
 import static se.sundsvall.seabloader.integration.db.model.enums.Status.PROCESSED;
 
+import java.util.List;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,6 +12,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import se.sundsvall.seabloader.integration.db.InvoiceRepository;
+import se.sundsvall.seabloader.integration.db.model.InvoiceId;
 import se.sundsvall.seabloader.integration.db.model.enums.Status;
 import se.sundsvall.seabloader.scheduler.AbstractScheduler;
 
@@ -35,11 +38,18 @@ public class DatabaseCleanerSchedulerService extends AbstractScheduler {
 		final var entitiesToRemove = invoiceRepository.countByStatusIn(STATUSES_TO_REMOVE);
 		if (entitiesToRemove > 0) {
 			LOGGER.info(LOG_ENTITIES_REMOVAL, entitiesToRemove, STATUSES_TO_REMOVE);
-			invoiceRepository.deleteAll(invoiceRepository.findByStatusIn(STATUSES_TO_REMOVE));
+			invoiceRepository.deleteAllById(getIdsToRemove());
 		} else {
 			LOGGER.info(LOG_NOTHING_TO_REMOVE, (Object) STATUSES_TO_REMOVE);
 		}
 
 		LOGGER.info(LOG_CLEANING_ENDED);
+	}
+
+	private List<Long> getIdsToRemove() {
+		return invoiceRepository.findIdsByStatusIn(STATUSES_TO_REMOVE)
+			.stream()
+			.map(InvoiceId::getId)
+			.toList();
 	}
 }

--- a/src/test/java/se/sundsvall/seabloader/integration/db/InvoiceRepositoryTest.java
+++ b/src/test/java/se/sundsvall/seabloader/integration/db/InvoiceRepositoryTest.java
@@ -16,6 +16,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 
 import se.sundsvall.seabloader.integration.db.model.InvoiceEntity;
+import se.sundsvall.seabloader.integration.db.model.InvoiceId;
 
 /**
  * InvoiceRepository tests
@@ -158,6 +159,19 @@ class InvoiceRepositoryTest {
 	void countByStatusIn() {
 		// Call
 		assertThat(repository.countByStatusIn(FAILED, PROCESSED)).isEqualTo(2);
+	}
+
+	@Test
+	void getByStatusIn() {
+
+		// Call
+		final var result = repository.findIdsByStatusIn(FAILED, PROCESSED);
+
+		// Verification
+		assertThat(result).hasSize(2);
+		assertThat(result)
+			.extracting(InvoiceId::getId)
+			.containsExactlyInAnyOrder(5L, 6L);
 	}
 
 	private static InvoiceEntity createInvoiceEntity() {

--- a/src/test/java/se/sundsvall/seabloader/integration/db/InvoiceRepositoryTest.java
+++ b/src/test/java/se/sundsvall/seabloader/integration/db/InvoiceRepositoryTest.java
@@ -162,7 +162,7 @@ class InvoiceRepositoryTest {
 	}
 
 	@Test
-	void getByStatusIn() {
+	void findIdsByStatusIn() {
 
 		// Call
 		final var result = repository.findIdsByStatusIn(FAILED, PROCESSED);

--- a/src/test/java/se/sundsvall/seabloader/scheduler/dbcleaner/DatabaseCleanerSchedulerServiceTest.java
+++ b/src/test/java/se/sundsvall/seabloader/scheduler/dbcleaner/DatabaseCleanerSchedulerServiceTest.java
@@ -14,7 +14,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import se.sundsvall.seabloader.integration.db.InvoiceRepository;
-import se.sundsvall.seabloader.integration.db.model.InvoiceEntity;
+import se.sundsvall.seabloader.integration.db.model.InvoiceId;
 import se.sundsvall.seabloader.integration.db.model.enums.Status;
 
 @ExtendWith(MockitoExtension.class)
@@ -29,19 +29,19 @@ class DatabaseCleanerSchedulerServiceTest {
 	@Test
 	void executeWithEntitiesToRemove() {
 		// Setup
-		final var entitiesToRemove = List.of(InvoiceEntity.create(), InvoiceEntity.create());
+		final var entityIdsToRemove = createInvoiceIds();
 
 		// Setup mocking
-		when(invoiceRepositoryMock.countByStatusIn(Status.PROCESSED)).thenReturn(Integer.toUnsignedLong(entitiesToRemove.size()));
-		when(invoiceRepositoryMock.findByStatusIn(Status.PROCESSED)).thenReturn(entitiesToRemove);
+		when(invoiceRepositoryMock.countByStatusIn(Status.PROCESSED)).thenReturn(Integer.toUnsignedLong(entityIdsToRemove.size()));
+		when(invoiceRepositoryMock.findIdsByStatusIn(Status.PROCESSED)).thenReturn(entityIdsToRemove);
 
 		// Call.
 		service.execute();
 
 		// Verification.
 		verify(invoiceRepositoryMock).countByStatusIn(Status.PROCESSED);
-		verify(invoiceRepositoryMock).findByStatusIn(Status.PROCESSED);
-		verify(invoiceRepositoryMock).deleteAll(entitiesToRemove);
+		verify(invoiceRepositoryMock).findIdsByStatusIn(Status.PROCESSED);
+		verify(invoiceRepositoryMock).deleteAllById(List.of(5L, 6L));
 	}
 
 	@Test
@@ -51,7 +51,20 @@ class DatabaseCleanerSchedulerServiceTest {
 
 		// Verification.
 		verify(invoiceRepositoryMock).countByStatusIn(Status.PROCESSED);
-		verify(invoiceRepositoryMock, never()).findByStatusIn(any());
-		verify(invoiceRepositoryMock, never()).deleteAll(any());
+		verify(invoiceRepositoryMock, never()).findIdsByStatusIn(any());
+		verify(invoiceRepositoryMock, never()).deleteAllById(any());
+	}
+
+	private List<InvoiceId> createInvoiceIds() {
+		return List.of(createInvoiceIdInstance(5L), createInvoiceIdInstance(6L));
+	}
+
+	private InvoiceId createInvoiceIdInstance(long id) {
+		return new InvoiceId() {
+			@Override
+			public long getId() {
+				return id;
+			}
+		};
 	}
 }


### PR DESCRIPTION
- Refactored cleaning job to use ids of entities instead of fetching
complete objects when cleaning obsolete entities from db